### PR TITLE
Add listserv signup

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,7 +83,7 @@
 			$.ajax({
 				type: "POST",
 				crossDomain: true,
-				url: "http://dbaxqhkdmfkhz.cloudfront.net/https://list.nih.gov/cgi-bin/wa.exeAAAAA",
+				url: "http://dbaxqhkdmfkhz.cloudfront.net/https://list.nih.gov/cgi-bin/wa.exe",
 				headers: ['origin', 'x-requested-with'],
 				beforeSend: function() {
 				    $('span#contact-form').html('Loading...');


### PR DESCRIPTION
I know we had gone back and forth on this, but based on the fact that I got 6 emails in the past week asking to be added to a listserv about openFDA I think having the ability to sign up publicly would be a good idea. This commit swaps out the contact section for a jquery ajax form that issues a POST to the NIH listserv system with the email address of the requesting user.
