### PR TITLE
Fix a typo in the drug API reference

### DIFF
--- a/drug/event/reference/index.md
+++ b/drug/event/reference/index.md
@@ -66,7 +66,7 @@ Reporting of adverse events by healthcare professionals and consumers is volunta
 
 ### Responsible use of the data
 
-Adverse rvent reports submitted to FDA do not undergo extensive validation or verification. Therefore, **a causal relationship cannot be established between product and reactions listed in a report.** While a suspected relationship *may* exist, it is not medically validated and should not be the sole source of information for clinical decision making or other assumptions about the safety or efficacy of a product.
+Adverse event reports submitted to FDA do not undergo extensive validation or verification. Therefore, **a causal relationship cannot be established between product and reactions listed in a report.** While a suspected relationship *may* exist, it is not medically validated and should not be the sole source of information for clinical decision making or other assumptions about the safety or efficacy of a product.
 
 Additionally, it is important to remember that adverse event reports represent a small percentage of total usage numbers of a product. Common products may have a higher number of adverse events due to the higher total number of people using the product. In recent years the FDA has undertaken efforts to increase collection of adverse events. Increases in the total number of adverse events is likely caused by improved reporting.
 


### PR DESCRIPTION
Just noticed this while browsing the site.
