### PR TITLE
Adds an RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,12 @@
 name: openFDA
+url: https://open.fda.gov
 
 markdown: kramdown
 kramdown:
   use_coderay: true
   coderay_line_numbers: nil
   parse_block_html: true
-  
+
 pygments: true
 baseurl: /openfda-private-beta
 permalink: /update/:title/

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,9 @@
     <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
     <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>
     <link href="{{ site.baseurl }}/static/css/style.css" rel="stylesheet">
+
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} &raquo; Feed" href="{{ site.baseurl }}/feed/" />
+
     <!--[if lt IE 9]>
       <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
       <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,34 @@
+---
+layout: none
+permalink: /feed/
+json: false
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+  xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+  >
+<channel>
+    <title xml:lang="en">{{ site.name}}</title>
+    <atom:link type="application/atom+xml" href="{{ site.url }}/feed/" rel="self"/>
+    <link>{{ site.url }}</link>
+    <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+    <lastBuildDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</lastBuildDate>
+    <language>en-US</language>
+    <description>{{ site.welcome_message }}</description>
+    {% for post in site.posts limit:site.rss_limit %}<item>
+        <title>{{ post.title }}</title>
+        <link>{{ site.url }}{{ post.url }}</link>
+        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <dc:creator>{{ post.author }}</dc:creator>
+        {% for tag in post.tags %}<category>{{ tag | xml_escape }}</category>
+        {% endfor %}{% for cat in post.categories %}<category>{{ cat | xml_escape }}</category>
+        {% endfor %}<guid isPermaLink="false">{{ post.id }}</guid>
+        <description><![CDATA[ {{ post.content }} ]]></description>
+    </item>{% endfor %}
+</channel>
+</rss>


### PR DESCRIPTION
Adds an RSS feed for updates to `/feed/`. This uses the existing `site.name` as the feed title, and `site.welcome_message` as the feed description. I did add a `site.url` to `_config.yml` to provide an absolute canonical URL inside the feed.
