### PR TITLE
Update openFDA about page and FAERS download info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages'

--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ This repository contains the main open.fda.gov website:
 
 # Running the site
 
-Install Jekyll and Grunt:
+Install Bundler, Jekyll and Grunt:
 
 ```bash
-gem install jekyll
 npm install -g grunt-cli
+gem install bundler
+cd /path/to/this/repo
+bundle install
 ```
 
 Get Grunt watching for any changes to assets:
@@ -29,7 +31,7 @@ grunt
 Get the site running at `http://localhost:4000` with:
 
 ```
-jekyll serve --baseurl=""
+bundle exec jekyll serve
 ```
 
 (Optional) You can also manually recompile assets at any time by running:
@@ -41,6 +43,5 @@ grunt minified
 
 # Prerequisites
 
-* Jekyll 1.x/2.x
-* Grunt 0.4.x
-* Python 2.x (because of [pygments](https://github.com/tmm1/pygments.rb) syntax highlighting)
+* Node 0.10.*
+* Python 2.* (because of [pygments](https://github.com/tmm1/pygments.rb) syntax highlighting)

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ kramdown:
   parse_block_html: true
 
 pygments: true
-baseurl: /
 permalink: /update/:title/
+baseurl: ""
 
 welcome_message: "A research project to provide open APIs, raw data downloads, documentation and examples, and a developer community for an important collection of FDA public datasets."

--- a/about/index.md
+++ b/about/index.md
@@ -42,9 +42,11 @@ The team also wishes to thank the following individuals for their contributions 
 - Steven Hubbard
 - Erie Meyer
 - Nick Muerdter
+- Joe Neubauer
 - Brian Norris
 - John Quinn
 - Mark Silverberg
+- Zhiheng (Roy) Xu
 
 ## How can I join in?
 

--- a/drug/event/index.md
+++ b/drug/event/index.md
@@ -12,6 +12,7 @@ endpoints:
       - name: API Reference
         url: /drug/reference/
 ---
+{::nomarkdown}
 <section class="content-heading api {% if page.cover %}cover{% endif %}" style="background-image:url('{{ site.baseurl }}/assets/img/{{ page.cover }}');">
   <div class="content-heading-text">
     <div class="content-heading-title">
@@ -26,6 +27,7 @@ endpoints:
   <div class="col-sm-4 tab"><h2>Product labels <span style="font-size: 9px">Coming soon</span></h2></div>
   <div class="col-sm-4 tab"><h2>Recalls <span style="font-size: 9px">Coming soon</span></h2></div>
 </div>
+{:/}
 
 <section id="endpoint">
 

--- a/drug/event/reference/index.md
+++ b/drug/event/reference/index.md
@@ -62,7 +62,9 @@ Adverse event reports use the [ICH E2b/M2 version 2.1 standard.](http://estri.ic
 
 ### Data downloads
 
-FDA releases [quarterly updates to FAERS data.](http://www.fda.gov/Drugs/GuidanceComplianceRegulatoryInformation/Surveillance/AdverseDrugEffects/ucm082193.htm) OpenFDA uses these extracts, but processes the data further before supplying them through the API. During our beta, we are investigating the best ways to offer direct downloads of data provided by the API. 
+FDA releases [quarterly updates to FAERS data.](http://www.fda.gov/Drugs/GuidanceComplianceRegulatoryInformation/Surveillance/AdverseDrugEffects/ucm082193.htm) OpenFDA uses these extracts, but processes the data further before supplying them through the API. During our beta testing, we are investigating the best ways to offer direct downloads of data provided by the API.
+
+There are no plans for the OpenFDA initiative to change the FAERS release protocols. At this time it is anticipated that FAERS downloads will continue to be available from the same site on the same quarterly schedule. OpenFDA is a research project to make access to these datasets easier, not replace the current process. The information available through openFDA is not for clinical production use and is in beta testing. While the FDA makes every effort to ensure the data is accurate, it should be assumed that all results are not validated.
 
 ### Who reports adverse events?
 
@@ -284,7 +286,7 @@ Each adverse event report consists of these major sections:
 - **Patient Information:** Details on the patient who experienced the event, such as age, weight, sex, etc.
 - **Drugs:** Information on the drugs taken while the event was experienced
 - **Ractions:** Information on the reactions experienced by the patient
- 
+
 ### Field reference
 
 #### Header
@@ -591,7 +593,7 @@ patient: {
 : `802` = Month
 : `803` = Week
 : `804` = Day
-: `805` = Hour 
+: `805` = Hour
 
 `patient.patientsex`
 : **String**
@@ -659,7 +661,7 @@ patient: {
 : `802` = Month
 : `803` = Week
 : `804` = Day
-: `805` = Hour 
+: `805` = Hour
 : `806` = Minute
 : `807` = Trimester
 : `810` = Cyclical
@@ -803,7 +805,7 @@ patient: {
 : `802` = Month
 : `803` = Week
 : `804` = Day
-: `805` = Hour 
+: `805` = Hour
 : `806` = Minute
 
 `patient.drug.medicinalproduct`


### PR DESCRIPTION
Also updates the README on how to install Jekyll via bundler, so
everyone will have the same Jekyll setup as github-pages.
