### PR TITLE
Changed Open Data SE "openfda" Tag Link

### DIFF
--- a/_includes/getting-started.html
+++ b/_includes/getting-started.html
@@ -36,7 +36,7 @@
       <h3>Meet the data</h3>
       <p>Use this page's interactive queries to learn the endpoint, and take advantage of the <a href="reference/">field-by-field reference</a>.</p>
       <p>Ask questions and give feedback where other developers can benefit from the discussion:</p>
-      <blockquote><a href="http://stackexchange.com/search?q=openfda">Ask questions on StackExchange</a> (tag with <em>openfda</em>)</blockquote>
+      <blockquote><a href="https://opendata.stackexchange.com/questions/tagged/openfda">Ask questions on Open Data Stack Exchange</a> (tag with <em>openfda</em>)</blockquote>
       <blockquote><a href="http://github.com/FDA/">Log bugs or suggest improvements</a> on GitHub</blockquote>
     </div>
   </div>


### PR DESCRIPTION
Pointed reference link to Open Data SE "openfda" tags; Other links in open.fda.gov point there, and I know that it is used as this agencies forum, amongst others...
